### PR TITLE
Add CLI script for decrypting XOR-encrypted files

### DIFF
--- a/decrypt_file.py
+++ b/decrypt_file.py
@@ -1,0 +1,23 @@
+
+import sys
+
+def xor_decrypt(file_path: str, key: str):
+    key_bytes = key.encode("utf-8")
+
+    with open(file_path, "rb") as f:
+        data = f.read()
+
+    decrypted_bytes = [b ^ key_bytes[i % len(key_bytes)] for i, b in enumerate(data)]
+    result = bytes(decrypted_bytes).decode("utf-8", errors="ignore")
+    print(result)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(f"Usage: python {sys.argv[0]} <file_path> <key>")
+        sys.exit(1)
+
+    file_path = sys.argv[1]  # הפרמטר הראשון אחרי שם הסקריפט
+    key = sys.argv[2]        # הפרמטר השני אחרי שם הסקריפט
+
+    xor_decrypt(file_path, key)


### PR DESCRIPTION
This script (file_decrypt_cli.py) allows the user to decrypt a file encrypted with a simple XOR key. The script accepts two command-line arguments: the path to the encrypted file and the XOR key. It reads the file in binary mode, applies the XOR decryption, and prints the resulting text to stdout.

Usage example:
python file_decrypt_cli.py secret.txt benny